### PR TITLE
Update readme with supported testnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ in a third terminal start the NextJS front end:
 ```
 
 ## Solved! (Final Steps)
-Once you have a working solution and all the tests are passing your next move is to deploy your lovely contract to the Sepolia testnet.
+Once you have a working solution and all the tests are passing, your next move is to deploy your contract to a supported testnet (for example, Sepolia).
 
 ### Setting up your wallet (if you haven't already)
 First you will need to generate an account. **You can skip this step if you have already created a keystore on your machine. Keystores are located in `~/.foundry/keystores`**
@@ -102,18 +102,18 @@ Run the following to view your new address and balances across several networks.
 ```bash
   yarn account
 ```
-To fund your account with Sepolia ETH simply search for "Sepolia testnet faucet" on Google or ask around in onchain developer groups who are usually more than willing to share. Send the funds to your wallet address and run `yarn account` again to verify the funds show in your Sepolia balance.
+To fund your account with testnet ETH, use a faucet for your chosen network (for example, a Sepolia faucet). Send the funds to your wallet address and run `yarn account` again to verify the funds show in your chosen network balance.
 
 ### Deploying your contract
 Note: We use Sepolia below as an example, but you can deploy to any of the supported testnets recognized by the ETH Tech Tree. See the [list of supported testnets](https://github.com/BuidlGuidl/eth-tech-tree-backend/blob/12799cc95950ee3bd8d523b8d2d2e2f05f131268/packages/server/utils/config.ts#L21). Use the `--network <name>` flag accordingly.
-Once you have confirmed your balance on Sepolia you can run this command to deploy your contract.
+Once you have confirmed your balance on your chosen testnet, you can run the following command to deploy your contract (example uses Sepolia).
 ```bash
   yarn deploy --network sepolia
 ```
-Now you need to verify it on Sepolia Etherscan.
+Now verify it on the block explorer for your chosen testnet (example: Sepolia Etherscan).
 ```bash
   yarn verify --network sepolia
 ```
-Copy your deployed contract address from your console and paste it in at [sepolia.etherscan.io](https://sepolia.etherscan.io). You should see a green checkmark on the "Contract" tab showing that the source code has been verified.
+Copy your deployed contract address and paste it into the appropriate block explorer for your chosen testnet (for example, [sepolia.etherscan.io](https://sepolia.etherscan.io)). You should see a green checkmark on the "Contract" tab showing that the source code has been verified.
 
 Now you can return to the ETH Tech Tree CLI, navigate to this challenge in the tree and submit your deployed contract address. Congratulations!

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Run the following to view your new address and balances across several networks.
 To fund your account with Sepolia ETH simply search for "Sepolia testnet faucet" on Google or ask around in onchain developer groups who are usually more than willing to share. Send the funds to your wallet address and run `yarn account` again to verify the funds show in your Sepolia balance.
 
 ### Deploying your contract
+Note: We use Sepolia below as an example, but you can deploy to any of the supported testnets recognized by the ETH Tech Tree. See the [list of supported testnets](https://github.com/BuidlGuidl/eth-tech-tree-backend/blob/12799cc95950ee3bd8d523b8d2d2e2f05f131268/packages/server/utils/config.ts#L21). Use the `--network <name>` flag accordingly.
 Once you have confirmed your balance on Sepolia you can run this command to deploy your contract.
 ```bash
   yarn deploy --network sepolia

--- a/extension/README.md.args.mjs
+++ b/extension/README.md.args.mjs
@@ -100,6 +100,7 @@ Run the following to view your new address and balances across several networks.
 To fund your account with Sepolia ETH simply search for "Sepolia testnet faucet" on Google or ask around in onchain developer groups who are usually more than willing to share. Send the funds to your wallet address and run \`yarn account\` again to verify the funds show in your Sepolia balance.
 
 ### Deploying your contract
+Note: We use Sepolia below as an example, but you can deploy to any of the supported testnets recognized by the ETH Tech Tree. See the [list of supported testnets](https://github.com/BuidlGuidl/eth-tech-tree-backend/blob/12799cc95950ee3bd8d523b8d2d2e2f05f131268/packages/server/utils/config.ts#L21). Use the \`--network <name>\` flag accordingly.
 Once you have confirmed your balance on Sepolia you can run this command to deploy your contract.
 \`\`\`bash
   yarn deploy --network sepolia

--- a/extension/README.md.args.mjs
+++ b/extension/README.md.args.mjs
@@ -79,7 +79,7 @@ in a third terminal start the NextJS front end:
 \`\`\`
 
 ## Solved! (Final Steps)
-Once you have a working solution and all the tests are passing your next move is to deploy your lovely contract to the Sepolia testnet.
+Once you have a working solution and all the tests are passing, your next move is to deploy your contract to a supported testnet (for example, Sepolia).
 
 ### Setting up your wallet (if you haven't already)
 First you will need to generate an account. **You can skip this step if you have already created a keystore on your machine. Keystores are located in \`~/.foundry/keystores\`**
@@ -97,19 +97,19 @@ Run the following to view your new address and balances across several networks.
 \`\`\`bash
   yarn account
 \`\`\`
-To fund your account with Sepolia ETH simply search for "Sepolia testnet faucet" on Google or ask around in onchain developer groups who are usually more than willing to share. Send the funds to your wallet address and run \`yarn account\` again to verify the funds show in your Sepolia balance.
+To fund your account with testnet ETH, use a faucet for your chosen network (for example, a Sepolia faucet). Send the funds to your wallet address and run \`yarn account\` again to verify the funds show in your chosen network balance.
 
 ### Deploying your contract
 Note: We use Sepolia below as an example, but you can deploy to any of the supported testnets recognized by the ETH Tech Tree. See the [list of supported testnets](https://github.com/BuidlGuidl/eth-tech-tree-backend/blob/12799cc95950ee3bd8d523b8d2d2e2f05f131268/packages/server/utils/config.ts#L21). Use the \`--network <name>\` flag accordingly.
-Once you have confirmed your balance on Sepolia you can run this command to deploy your contract.
+Once you have confirmed your balance on your chosen testnet, you can run the following command to deploy your contract (example uses Sepolia).
 \`\`\`bash
   yarn deploy --network sepolia
 \`\`\`
-Now you need to verify it on Sepolia Etherscan.
+Now verify it on the block explorer for your chosen testnet (example: Sepolia Etherscan).
 \`\`\`bash
   yarn verify --network sepolia
 \`\`\`
-Copy your deployed contract address from your console and paste it in at [sepolia.etherscan.io](https://sepolia.etherscan.io). You should see a green checkmark on the "Contract" tab showing that the source code has been verified.
+Copy your deployed contract address and paste it into the appropriate block explorer for your chosen testnet (for example, [sepolia.etherscan.io](https://sepolia.etherscan.io)). You should see a green checkmark on the "Contract" tab showing that the source code has been verified.
 
 Now you can return to the ETH Tech Tree CLI, navigate to this challenge in the tree and submit your deployed contract address. Congratulations!
 `;


### PR DESCRIPTION
Update READMEs to clarify that Sepolia is an example and link to all supported testnets for contract deployment.

---
<a href="https://cursor.com/background-agent?bcId=bc-529de6c1-ea75-47ed-b9aa-65bedc474e88">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-529de6c1-ea75-47ed-b9aa-65bedc474e88">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

