### PR TITLE
Update readme with supported testnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,14 +73,15 @@ Run the following to view your new address and balances across several networks.
 To fund your account with Sepolia ETH simply search for "Sepolia testnet faucet" on Google or ask around in onchain developer groups who are usually more than willing to share. Send the funds to your wallet address and run `yarn account` again to verify the funds show in your Sepolia balance.
 
 ### Deploying your contract
-Once you have confirmed your balance on Sepolia you can run this command to deploy your contract.
+Note: Sepolia is used below as an example. However, multiple testnets are supported for submissions. See the up-to-date list of supported testnets in the [backend config](https://github.com/BuidlGuidl/eth-tech-tree-backend/blob/12799cc95950ee3bd8d523b8d2d2e2f05f131268/packages/server/utils/config.ts#L21). Choose any from that list and replace `sepolia` in the commands with your chosen network name.
+Once you have confirmed your balance on your chosen supported testnet (Sepolia shown below) you can run this command to deploy your contract.
 ```bash
   yarn deploy --network sepolia
 ```
-Now you need to verify it on Sepolia Etherscan.
+Now you need to verify it on the block explorer for your chosen network (Sepolia Etherscan shown below).
 ```bash
   yarn verify --network sepolia
 ```
-Copy your deployed contract address from your console and paste it in at [sepolia.etherscan.io](https://sepolia.etherscan.io). You should see a green checkmark on the "Contract" tab showing that the source code has been verified.
+Copy your deployed contract address from your console and paste it into the explorer (for Sepolia: [sepolia.etherscan.io](https://sepolia.etherscan.io)). You should see a green checkmark on the "Contract" tab showing that the source code has been verified.
 
 Now you can return to the ETH Tech Tree CLI, navigate to this challenge in the tree and submit your deployed contract address. Congratulations!

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ in a third terminal start the NextJS front end:
 ```
 
 ## Solved! (Final Steps)
-Once you have a working solution and all the tests are passing your next move is to deploy your lovely contract to the Sepolia testnet.
+Once you have a working solution and all the tests are passing your next move is to deploy your lovely contract to a supported testnet (for example, Sepolia).
 
 ### Setting up your wallet (if you haven't already)
 First you will need to generate an account. **You can skip this step if you have already created a keystore on your machine. Keystores are located in `~/.foundry/keystores`**
@@ -70,7 +70,7 @@ Run the following to view your new address and balances across several networks.
 ```bash
   yarn account
 ```
-To fund your account with Sepolia ETH simply search for "Sepolia testnet faucet" on Google or ask around in onchain developer groups who are usually more than willing to share. Send the funds to your wallet address and run `yarn account` again to verify the funds show in your Sepolia balance.
+To fund your account with testnet ETH on your chosen network, search for a faucet (for example, "Sepolia testnet faucet" if using Sepolia) or ask around in onchain developer groups who are usually more than willing to share. Send the funds to your wallet address and run `yarn account` again to verify the funds show in your balance for that network.
 
 ### Deploying your contract
 Note: Sepolia is used below as an example. However, multiple testnets are supported for submissions. See the up-to-date list of supported testnets in the [backend config](https://github.com/BuidlGuidl/eth-tech-tree-backend/blob/12799cc95950ee3bd8d523b8d2d2e2f05f131268/packages/server/utils/config.ts#L21). Choose any from that list and replace `sepolia` in the commands with your chosen network name.


### PR DESCRIPTION
Clarify supported testnets in README's 'Deploying your contract' section and link to the full list.

---
<a href="https://cursor.com/background-agent?bcId=bc-6a2006c5-5210-4e75-a977-91adc1e42770">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6a2006c5-5210-4e75-a977-91adc1e42770">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

