### PR TITLE
Update readme with supported testnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Run the following to view your new address and balances across several networks.
 To fund your account with Sepolia ETH simply search for "Sepolia testnet faucet" on Google or ask around in onchain developer groups who are usually more than willing to share. Send the funds to your wallet address and run `yarn account` again to verify the funds show in your Sepolia balance.
 
 ### Deploying your contract
+Sepolia is used below as an example. You can deploy to any of the supported testnets listed here: [supported testnets](https://github.com/BuidlGuidl/eth-tech-tree-backend/blob/12799cc95950ee3bd8d523b8d2d2e2f05f131268/packages/server/utils/config.ts#L21). Update the `--network` flag accordingly.
 Once you have confirmed your balance on Sepolia you can run this command to deploy your contract.
 ```bash
   yarn deploy --network sepolia

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ in a third terminal start the NextJS front end:
 ```
 
 ## Solved! (Final Steps)
-Once you have a working solution and all the tests are passing your next move is to deploy your lovely contract to the Sepolia testnet.
+Once you have a working solution and all the tests are passing your next move is to deploy your lovely contract to a supported testnet (e.g., Sepolia).
 
 ### Setting up your wallet (if you haven't already)
 First you will need to generate an account. **You can skip this step if you have already created a keystore on your machine. Keystores are located in `~/.foundry/keystores`**
@@ -116,18 +116,18 @@ Run the following to view your new address and balances across several networks.
 ```bash
   yarn account
 ```
-To fund your account with Sepolia ETH simply search for "Sepolia testnet faucet" on Google or ask around in onchain developer groups who are usually more than willing to share. Send the funds to your wallet address and run `yarn account` again to verify the funds show in your Sepolia balance.
+To fund your account with testnet ETH, use a faucet for your chosen network (for example, search for a "Sepolia testnet faucet"). Send the funds to your wallet address and run `yarn account` again to verify the funds show in your balance on that network.
 
 ### Deploying your contract
 Sepolia is used below as an example. You can deploy to any of the supported testnets listed here: [supported testnets](https://github.com/BuidlGuidl/eth-tech-tree-backend/blob/12799cc95950ee3bd8d523b8d2d2e2f05f131268/packages/server/utils/config.ts#L21). Update the `--network` flag accordingly.
-Once you have confirmed your balance on Sepolia you can run this command to deploy your contract.
+Once you have confirmed your balance on your chosen testnet, you can run this command to deploy your contract (example uses Sepolia).
 ```bash
   yarn deploy --network sepolia
 ```
-Now you need to verify it on Sepolia Etherscan.
+Now verify it on the block explorer for your network (example: Sepolia Etherscan).
 ```bash
   yarn verify --network sepolia
 ```
-Copy your deployed contract address from your console and paste it in at [sepolia.etherscan.io](https://sepolia.etherscan.io). You should see a green checkmark on the "Contract" tab showing that the source code has been verified.
+Copy your deployed contract address from your console and paste it into the block explorer for your network (for example, [sepolia.etherscan.io](https://sepolia.etherscan.io)). You should see a green checkmark on the "Contract" tab showing that the source code has been verified.
 
 Now you can return to the ETH Tech Tree CLI, navigate to this challenge in the tree and submit your deployed contract address. Congratulations!

--- a/extension/README.md.args.mjs
+++ b/extension/README.md.args.mjs
@@ -93,7 +93,7 @@ in a third terminal start the NextJS front end:
 \`\`\`
 
 ## Solved! (Final Steps)
-Once you have a working solution and all the tests are passing your next move is to deploy your lovely contract to the Sepolia testnet.
+Once you have a working solution and all the tests are passing your next move is to deploy your lovely contract to a supported testnet (e.g., Sepolia).
 
 ### Setting up your wallet (if you haven't already)
 First you will need to generate an account. **You can skip this step if you have already created a keystore on your machine. Keystores are located in \`~/.foundry/keystores\`**
@@ -111,19 +111,19 @@ Run the following to view your new address and balances across several networks.
 \`\`\`bash
   yarn account
 \`\`\`
-To fund your account with Sepolia ETH simply search for "Sepolia testnet faucet" on Google or ask around in onchain developer groups who are usually more than willing to share. Send the funds to your wallet address and run \`yarn account\` again to verify the funds show in your Sepolia balance.
+To fund your account with testnet ETH, use a faucet for your chosen network (for example, search for a "Sepolia testnet faucet"). Send the funds to your wallet address and run \`yarn account\` again to verify the funds show in your balance on that network.
 
 ### Deploying your contract
 Sepolia is used below as an example. You can deploy to any of the supported testnets listed here: [supported testnets](https://github.com/BuidlGuidl/eth-tech-tree-backend/blob/12799cc95950ee3bd8d523b8d2d2e2f05f131268/packages/server/utils/config.ts#L21). Update the \`--network\` flag accordingly.
-Once you have confirmed your balance on Sepolia you can run this command to deploy your contract.
+Once you have confirmed your balance on your chosen testnet, you can run this command to deploy your contract (example uses Sepolia).
 \`\`\`bash
   yarn deploy --network sepolia
 \`\`\`
-Now you need to verify it on Sepolia Etherscan.
+Now verify it on the block explorer for your network (example: Sepolia Etherscan).
 \`\`\`bash
   yarn verify --network sepolia
 \`\`\`
-Copy your deployed contract address from your console and paste it in at [sepolia.etherscan.io](https://sepolia.etherscan.io). You should see a green checkmark on the "Contract" tab showing that the source code has been verified.
+Copy your deployed contract address from your console and paste it into the block explorer for your network (for example, [sepolia.etherscan.io](https://sepolia.etherscan.io)). You should see a green checkmark on the "Contract" tab showing that the source code has been verified.
 
 Now you can return to the ETH Tech Tree CLI, navigate to this challenge in the tree and submit your deployed contract address. Congratulations!
 `;

--- a/extension/README.md.args.mjs
+++ b/extension/README.md.args.mjs
@@ -114,6 +114,7 @@ Run the following to view your new address and balances across several networks.
 To fund your account with Sepolia ETH simply search for "Sepolia testnet faucet" on Google or ask around in onchain developer groups who are usually more than willing to share. Send the funds to your wallet address and run \`yarn account\` again to verify the funds show in your Sepolia balance.
 
 ### Deploying your contract
+Sepolia is used below as an example. You can deploy to any of the supported testnets listed here: [supported testnets](https://github.com/BuidlGuidl/eth-tech-tree-backend/blob/12799cc95950ee3bd8d523b8d2d2e2f05f131268/packages/server/utils/config.ts#L21). Update the \`--network\` flag accordingly.
 Once you have confirmed your balance on Sepolia you can run this command to deploy your contract.
 \`\`\`bash
   yarn deploy --network sepolia


### PR DESCRIPTION
Clarify supported testnets in README deployment section and link to full list.

---
<a href="https://cursor.com/background-agent?bcId=bc-8ea6af62-7a57-47d5-a3a0-3c52f79d4516">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8ea6af62-7a57-47d5-a3a0-3c52f79d4516">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

